### PR TITLE
Fix code block syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The authorization used is custom - it follows no standard. It is most likely a t
 
 The Hub will provide APIs that allow FHIRCast clients that share context with it to subscribe to imaging study events, and to notify other clients (publish) the same imaging study events. Per the FHIRCast specification, these events are named, but we will support a limited set at this time:
 
-- pen-imaging-study
+- open-imaging-study
 - switch-imaging-study
 - close-imaging-study
 - user-logout

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ And receive the same topic as I did for user "joe", who is connecting from a dif
 
 The hub SHALL implement a REST method using the base URL as the endpoint. The specification conforms to WebSub specifications. The client will use the topic returned during authentication. Example:
 
+```
 POST https://hub.example.com
 
 Authorization: Bearer 61B584A8-C5AD-4A87-A40F-19E448EEBBAD
@@ -65,6 +66,7 @@ hub.topic=1A3DF21C-1451-4DC5-8B59-3F824D3A7ED7
 &amp;hub.mode=subscribe
 
 &amp;hub.channel.type=websocket
+```
 
 Notes:
 
@@ -83,108 +85,63 @@ Two encompassing objects will be used:
 4. The response message from the hub will contain one object containing the status, status – no header or body differentiation (see example below)
 
 Example Notification (Hub to client):
-
-"header":
-
+```json
 {
-
-"Authorization": "Bearer 61B584A8-C5AD-4A87-A40F-19E448EEBBAD",
-
-},
-
-"body":
-
-{
-
-  "timestamp": "2018-01-08T01:40:05.14",
-
-  "id": "wYXStHqxFQyHFELh",
-
-  "event": {
-
-    "hub.topic": "1A3DF21C-1451-4DC5-8B59-3F824D3A7ED7",
-
-    "hub.event": "close-imaging-study",
-
-    "context":
-
-[
-
-{
-
-      "key": "patient",
-
-      "resource": {
-
-        "resourceType": "Patient",
-
-        "id": "ewUbXT9RWEbSj5wPEdgRaBw3",
-
-        "identifier": [
-
-          {
-
-            "system": "urn:MRN",
-
-            "value": "2667"
-
+  "header": {
+    "Authorization": "Bearer 61B584A8-C5AD-4A87-A40F-19E448EEBBAD"
+  },
+  "body": {
+    "timestamp": "2018-01-08T01:40:05.14",
+    "id": "wYXStHqxFQyHFELh",
+    "event": {
+      "hub.topic": "1A3DF21C-1451-4DC5-8B59-3F824D3A7ED7",
+      "hub.event": "close-imaging-study",
+      "context": [
+        {
+          "key": "patient",
+          "resource": {
+            "resourceType": "Patient",
+            "id": "ewUbXT9RWEbSj5wPEdgRaBw3",
+            "identifier": [
+              {
+                "system": "urn:MRN",
+                "value": "2667"
+              }
+            ]
           }
+        },
+        {
+          "key": "study",
+          "resource": {
+            "resourceType": "ImagingStudy",
+            "id": "8i7tbu6fby5ftfbku6fniuf",
+            "uid": "urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045",
+            "identifier": [
+              {
+                "system": "urn:accession",
 
-        ]
-
-      }
-
-    },
-
-    {
-
-      "key": "study",
-
-      "resource": {
-
-        "resourceType": "ImagingStudy",
-
-        "id": "8i7tbu6fby5ftfbku6fniuf",
-
-        "uid": "urn:oid:2.16.124.113543.6003.1154777499.30246.19789.3503430045",
-
-        "identifier": [
-
-          {
-
-            "system": "urn:accession",
-
-            "value": "185444"
-
+                "value": "185444"
+              }
+            ],
+            "patient": {
+              "reference": "Patient/ewUbXT9RWEbSj5wPEdgRaBw3"
+            }
           }
-
-        ],
-
-        "patient": {
-
-          "reference": "Patient/ewUbXT9RWEbSj5wPEdgRaBw3"
-
         }
-
-      }
-
+      ]
     }
-
   }
-
-]
+}
+```
 
 Example Hub response:
-
+```json
 {
-
-"timestamp": "2018-01-08T01:40:05.14",
-
-"status": "OK",
-
-"statusCode": "200",
-
+  "timestamp": "2018-01-08T01:40:05.14",
+  "status": "OK",
+  "statusCode": "200"
 }
+```
 
 ### Establishing the WebSocket Connection
 
@@ -198,16 +155,13 @@ The hub will listen for the connection on the base URL, using an endpoint contai
 wss:_//hub.example.com/__1A3DF21C-1451-4DC5-8B59-3F824D3A7ED7_
 
 Example Response (hub to client):
-
+```json
 {
-
-"timestamp": "2018-01-08T01:40:05.14",
-
-"status": "OK",
-
-"statusCode": "200",
-
+  "timestamp": "2018-01-08T01:40:05.14",
+  "status": "OK",
+  "statusCode": "200"
 }
+```
 
 ### Get Current Context
 
@@ -218,21 +172,13 @@ GET https://hub.example.com/1A3DF21C-1451-4DC5-8B59-3F824D3A7ED7
 Authorization: Bearer 61B584A8-C5AD-4A87-A40F-19E448EEBBAD
 
  Potential response (context is a key/value array of FHIR Resources):
-
+```json 
 {
-
    "timestamp":"2018-01-08T01:40:05.14",
-
    "id":"wYXStHqxFQyHFELh",
-
    "event":{
-
       "hub.topic":"_1A3DF21C-1451-4DC5-8B59-3F824D3A7ED7_",
-
-      "context":[
-
-]
-
+      "context":[]
    }
-
 }
+```


### PR DESCRIPTION
In order to display the JSON examples prettier in README.md, they are now wrapped in code blocks  by placing triple backticks ``` before and after the code block.

For preview, see the README.md of the fork: [https://github.com/akalliokoski/.net/blob/master/README.md](https://github.com/akalliokoski/.net/blob/master/README.md)